### PR TITLE
Make the v2.0 API RESTful

### DIFF
--- a/frontend_src/dronebridge.js
+++ b/frontend_src/dronebridge.js
@@ -91,7 +91,7 @@ async function get_json(api_path) {
  * @param json_data JSON body data to send
  * @returns {Promise<any>}
  */
-async function send_json(api_path, json_data) {
+async function send_json(api_path, json_data = undefined) {
 	let post_url = ROOT_URL + api_path;
 	const response = await fetch(post_url, {
 		method: 'POST',
@@ -176,7 +176,7 @@ function get_stats() {
  *  returns 0 on success and -1 on failure
  */
 function get_settings() {
-	get_json("api/settings/request").then(json_data => {
+	get_json("api/settings").then(json_data => {
 		console.log("Received settings: " + json_data)
 		conn_status = 1
 		for (const key in json_data) {
@@ -208,7 +208,7 @@ function add_new_udp_client() {
 			ip: ip,
 			port: port
 		};
-		send_json("api/settings/addudp", JSON.stringify(myjson)).then(send_response => {
+		send_json("api/settings/clients/udp", JSON.stringify(myjson)).then(send_response => {
 			console.log(send_response);
 			conn_status = 1
 			show_toast(send_response["msg"])
@@ -239,7 +239,7 @@ function show_toast(msg) {
 function save_settings() {
 	let form = document.getElementById("settings_form")
 	let json_data = toJSONString(form)
-	send_json("api/settings/change", json_data).then(send_response => {
+	send_json("api/settings", json_data).then(send_response => {
 		console.log(send_response);
 		conn_status = 1
 		show_toast(send_response["msg"])
@@ -250,7 +250,7 @@ function save_settings() {
 }
 
 function trigger_reboot() {
-	get_json("api/system/reboot").then(json_data => {
+	send_json("api/system/reboot").then(json_data => {
 		show_toast(json_data["msg"])
 	}).catch(error => {
 		error.message;


### PR DESCRIPTION
Fixes #74.
This makes changes in the `frontend_src`, but I'm struggling to find any automated process that spits out a `index.html` with the minified versions, and so wasn't able to test this on real hardware just yet. Is that build manual right now?
If so, would you be open to automating it a little? I was thinking we could minify the `.js` files (toastify and our code) separately and including them with `<script src>` tags. That leads to nicer, piece-by-piece caching (IMO, and probably wholly irrelevant here) and easier build. 