### PR TITLE
Fix the GitHub Actions build

### DIFF
--- a/.github/actions/esp-idf-with-node/Dockerfile
+++ b/.github/actions/esp-idf-with-node/Dockerfile
@@ -1,0 +1,3 @@
+FROM espressif/idf:release-v5.1
+RUN apt update
+RUN apt -y install --no-install-recommends nodejs npm

--- a/.github/actions/esp-idf-with-node/action.yml
+++ b/.github/actions/esp-idf-with-node/action.yml
@@ -1,0 +1,22 @@
+name: "Espressif IoT Development Framework (ESP-IDF), plus node.js and npm"
+branding:
+  color: red
+  icon: wifi
+inputs:
+  target:
+    description: "ESP32 variant to build for"
+    default: "esp32"
+    required: false
+  command:
+    description: "Command to run inside the docker container (default: builds the project)"
+    default: "idf.py build"
+    required: false
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  env:
+    IDF_TARGET: "${{inputs.target}}"
+  args:
+    - "/bin/bash"
+    - "-c"
+    - "${{inputs.command}}"

--- a/.github/workflows/esp_idf.yml
+++ b/.github/workflows/esp_idf.yml
@@ -8,39 +8,17 @@ on:
 jobs:
   build_esp32_v5_1:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: ["esp32", "esp32s2", "esp32s3", "esp32c3"]
+      fail-fast: false
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - name: Setup node (npm)
-      uses: actions/setup-node@v4
+    - name: ESP-IDF v5.1 build
+      uses: ./.github/actions/esp-idf-with-node
       with:
-        node-version: 20
-        cache: 'npm'
-        cache-dependency-path: frontend/package-lock.json
-    - run: npm --prefix frontend ci
-    - name: ESP-IDF v5.1 build esp32
-      uses: espressif/esp-idf-ci-action@v1
-      with:
-        esp_idf_version: release-v5.1
-        target: esp32
-        command: 'idf.py set-target esp32 build'
-    - name: ESP-IDF v5.1 build esp32s2
-      uses: espressif/esp-idf-ci-action@v1
-      with:
-        esp_idf_version: release-v5.1
-        target: esp32s2
-        command: 'idf.py set-target esp32s2 build'
-    - name: ESP-IDF v5.1 build esp32s3
-      uses: espressif/esp-idf-ci-action@v1
-      with:
-        esp_idf_version: release-v5.1
-        target: esp32s3
-        command: 'idf.py set-target esp32s3 build'
-    - name: ESP-IDF v5.1 build esp32c3
-      uses: espressif/esp-idf-ci-action@v1
-      with:
-        esp_idf_version: release-v5.1
-        target: esp32c3
-        command: 'idf.py set-target esp32c3 build'
+        target: "${{ matrix.target }}"
+        command: "idf.py set-target ${{matrix.target}} build"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_target(
         COMMAND cmake -E make_directory "${CMAKE_BINARY_DIR}/frontend"
         COMMAND cmake -E make_directory "${CMAKE_SOURCE_DIR}/frontend/build"
         # Run frontend npm build process
-        COMMAND npm install && npm i -D shx && npm run build
+        COMMAND npm install && npm run build
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/frontend")
 # Copy the content of npm to the build directory
 add_custom_command(


### PR DESCRIPTION
By adding node.js and npm to the esp-idf container.
Build different targets in a matrix.

Fixes #79.

Successful run here: https://github.com/mmalecki/DroneBridge-ESP32/actions/runs/9264073314

An alternative implementation would be to avoid building the `frontend` target if the output directory is already present, but that could lead to stale build outputs when developing. Let me know what you think, and sorry for breaking this in the first place!