### PR TITLE
Clean up headers from `SRCS`

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,7 +1,5 @@
-idf_component_register(SRCS main.c db_esp32_control.c globals.h sdkconfig.h msp_ltm_serial.c
-        msp_ltm_serial.h db_protocol.h http_server.c http_server.h db_esp32_comm.c
-        db_esp32_comm.h db_comm_protocol.h db_comm.c db_comm.h db_crc.c db_crc.h tcp_server.c tcp_server.h
-        http_server.c http_server.h db_esp_now.c db_esp_now.h db_serial.c db_serial.h
+idf_component_register(SRCS main.c db_esp32_control.c msp_ltm_serial.c http_server.c
+        db_esp32_comm.c db_comm.c db_crc.c tcp_server.c db_esp_now.c db_serial.c
         INCLUDE_DIRS ".")
 
 if(CONFIG_WEB_DEPLOY_SF)


### PR DESCRIPTION
According to documentation, the headers don't need to be included within `SRCS`.