### PR TITLE
WIP: made BLE notification efficient

### DIFF
--- a/main/db_ble.c
+++ b/main/db_ble.c
@@ -227,7 +227,12 @@ static const struct ble_gatt_svc_def new_ble_svc_gatt_defs[] = {
         if (conn_handle_subs[i]) {
 
             /* Write to the characteristics */
-            int rc = ble_gatts_write(i,ble_spp_svc_gatt_notify_val_handle,data,data_len);
+            int rc = ble_gattc_write_flat(i,ble_spp_svc_gatt_notify_val_handle,
+                data,     /* Data pointer */
+                data_len, /* Data length */
+                NULL,     /* Callback function */
+                NULL      /* Callback function arguments */
+            );
             if (rc != 0) {
                 ESP_LOGE(TAG, "Failed to write characteristic value (rc = %d)", rc);
                 return rc;

--- a/main/db_ble.c
+++ b/main/db_ble.c
@@ -221,20 +221,20 @@ static const struct ble_gatt_svc_def new_ble_svc_gatt_defs[] = {
  * @param data_len Length of send buffer
  * @return 0 on success for all clients. -1 on failure to allocate buffer or ble_gatts_notify_custom return value
  */
-int db_ble_send_data(const uint8_t *data, uint16_t data_len) {
+ int db_ble_send_data(const uint8_t *data, uint16_t data_len) {
     for (int i = 0; i < CONFIG_BT_NIMBLE_MAX_CONNECTIONS; i++) {
         /* Check if the client has subscribed to notifications */
         if (conn_handle_subs[i]) {
-            struct os_mbuf *txom;
-            // Convert BleData_t struct data into an os_mbuf buffer
-            txom = ble_hs_mbuf_from_flat(data, data_len);
-            if (!txom) {
-                ESP_LOGE(TAG, "Failed to allocate os_mbuf (data length: %i)", data_len);
-                return -1;   // maybe we ran out of memory
+
+            /* Write to the characteristics */
+            int rc = ble_gatts_write(i,ble_spp_svc_gatt_notify_val_handle,data,data_len);
+            if (rc != 0) {
+                ESP_LOGE(TAG, "Failed to write characteristic value (rc = %d)", rc);
+                return rc;
             }
 
-            // Send BLE notification
-            int rc = ble_gatts_notify_custom(i, ble_spp_svc_gatt_notify_val_handle, txom);
+            /* Now send a notification with the updated characteristic value */
+            rc = ble_gatts_notify(i, ble_spp_svc_gatt_notify_val_handle);
             if (rc != 0) {
                 ESP_LOGE(TAG, "Error sending BLE notification rc = %d", rc);
                 return rc;


### PR DESCRIPTION
@seeul8er, I have updated the BLE send function, instead of allocating a os_buf every time just write the data to the characteristic value and then send this as a notification. 

This would have been non ideal if our read and write characteristics had been same, but since they are different, we don't care about writing value to the characteristics