### PR TITLE
fix: prevent subsequent prompts when adding UDP client is cancelled

### DIFF
--- a/frontend/dronebridge.js
+++ b/frontend/dronebridge.js
@@ -375,7 +375,9 @@ function get_settings() {
 
 function add_new_udp_client() {
 	let ip = prompt("Please enter the IP address of the UDP receiver", "192.168.2.X");
+	if (ip == null) return;
 	let port = prompt("Please enter the port number of the UDP receiver", "14550");
+	if (port == null) return;
 	port = parseInt(port);
 	let save_to_nvm = confirm("Save this UDP client to the permanent storage so it will be auto added after reboot/reset?\nYou can only save one UDP client to the memory. The old ones will be overwritten.\nSelect no if you only want to add this client for this session.");
 	const ippattern = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;

--- a/frontend/dronebridge.js
+++ b/frontend/dronebridge.js
@@ -375,9 +375,15 @@ function get_settings() {
 
 function add_new_udp_client() {
 	let ip = prompt("Please enter the IP address of the UDP receiver", "192.168.2.X");
-	if (ip == null) return;
+	if (ip == null) {
+		show_toast("Operation cancelled by user."); 
+		return;
+	}
 	let port = prompt("Please enter the port number of the UDP receiver", "14550");
-	if (port == null) return;
+	if (port == null) {
+		show_toast("Operation cancelled by user.")
+		return;
+	}
 	port = parseInt(port);
 	let save_to_nvm = confirm("Save this UDP client to the permanent storage so it will be auto added after reboot/reset?\nYou can only save one UDP client to the memory. The old ones will be overwritten.\nSelect no if you only want to add this client for this session.");
 	const ippattern = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;


### PR DESCRIPTION
Not much to explain. It simply cancels the subsequent prompts when you hit "cancel" on the IP or port prompt.