### PR TITLE
 fix: improve memory safety and UART driver stability

### DIFF
--- a/main/db_serial.c
+++ b/main/db_serial.c
@@ -91,7 +91,10 @@ esp_err_t open_uart_serial_socket() {
     ESP_ERROR_CHECK(uart_set_pin(UART_NUM, DB_PARAM_GPIO_TX, DB_PARAM_GPIO_RX,
                                  flow_control ? DB_PARAM_GPIO_RTS : UART_PIN_NO_CHANGE,
                                  flow_control ? DB_PARAM_GPIO_CTS : UART_PIN_NO_CHANGE));
-    return uart_driver_install(UART_NUM, 1024, 0, 10, NULL, 0);
+    if (!uart_is_driver_installed(UART_NUM)) {
+        return uart_driver_install(UART_NUM, 1024, 0, 10, NULL, 0);
+    }
+    return ESP_OK;
 }
 
 /**
@@ -133,6 +136,7 @@ esp_err_t open_serial_socket() {
  * @param data_length Size of payload to write to UART
  */
 void write_to_serial(const uint8_t data_buffer[], const unsigned int data_length) {
+    if (data_length == 0) return;
 #ifdef CONFIG_DB_SERIAL_OPTION_JTAG
     // Writes data from buffer to JTAG based serial interface
     int written = usb_serial_jtag_write_bytes(data_buffer, data_length, 20 / portTICK_PERIOD_MS);


### PR DESCRIPTION
  PR Description:


     This PR addresses several stability issues and potential crash points in t
      ESP32 control module, specifically focusing on memory management and
      hardware driver lifecycle.
    
     ### Key Changes:
    
     1. **Memory Safety (Heap Exhaustion Protection):**
        - Added `NULL` checks for `malloc()` calls in `db_send_to_all_espnow` a
          the Bluetooth (BLE) transmission path.
        - **Benefit:** Prevents Kernel Panics and random reboots if the system
          runs low on memory during high MAVLink throughput. The system will now log
          an error and skip the packet instead of crashing.
    
     2. **UART Driver Management:**
       - Added a `uart_is_driver_installed()` check before calling
        `uart_driver_install()` in `db_serial.c`.
       - **Benefit:** Prevents resource leaks and driver initialization errors
        when the control module is restarted (e.g., after a settings change in the
        Web UI).
   
   3. **Buffer Protection:**
       - Implemented a missing bounds check in `handle_internal_telemetry`.
       - **Benefit:** Prevents memory corruption/over-reads if a malformed or
        truncated internal telemetry packet is received from another station.
   
   4. **Hardware Efficiency:**
        - Added a zero-length guard in `write_to_serial()`.
        - **Benefit:** Prevents unnecessary calls to the underlying hardware
      drivers when there is no data to transmit.
   
    ### Testing Performed:
        - Verified stable UART re-initialization after settings changes.
        - Verified system stability under high data load (parameter downloads in
          QGroundControl).

  ---
