### PR TITLE
Show Flight Controller System ID in the Web Interface

### DIFF
--- a/frontend/dronebridge.js
+++ b/frontend/dronebridge.js
@@ -295,6 +295,13 @@ function get_stats() {
 		} else if (!isNaN(tcp_clients)) {
 			document.getElementById("tcp_connected").innerHTML = tcp_clients + " clients"
 		}
+
+		if (json_data["fc_connected"]) {
+			document.getElementById("fc_sys_id_div").innerHTML = "MAVLink System ID: " + json_data["fc_sys_id"];
+		} else {
+			document.getElementById("fc_sys_id_div").innerHTML = "No Flight Controller connected.";
+		}
+
 		// UDP clients for tooltip
 		let udp_clients_string = ""
 		if (json_data.hasOwnProperty("udp_clients")) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,8 +37,8 @@
                 <div id="current_client_ip" class="twelve columns small_text">
                 </div>
             </div>
-            <div class="row" id="fc_sys_id_div" class="twelve columns small_text">
-                <div id="fc_sys_id_div">
+            <div class="row">
+                <div id="fc_sys_id_div" class="twelve columns small_text">
                 </div>
             </div>
             <div class="row">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,11 +37,11 @@
                 <div id="current_client_ip" class="twelve columns small_text">
                 </div>
             </div>
-            <div class="row">
-                <div class="four columns">
-                    <label>received bytes serial port</label>
-                    <div id="read_bytes">-</div>
+            <div class="row" id="fc_sys_id_div" class="twelve columns small_text">
+                <div id="fc_sys_id_div">
                 </div>
+            </div>
+            <div class="row">
                 <div class="four columns">
                     <label>Connected TCP clients</label>
                     <div id="tcp_connected">-</div>
@@ -53,6 +53,12 @@
                         <img class="img_button" style="margin-left: 5rem; padding: 0.2rem" height="20em" alt="add" src="add_16dp_icon.png" onclick="add_new_udp_client()"/>
                         <img class="img_button" style="margin-left: 0.5rem; padding: 0.2rem" height="20em" alt="delete" src="remove_16dp_icon.png" onclick="clear_udp_clients()"/>
                     </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="four columns">
+                    <label>received bytes serial port</label>
+                    <div id="read_bytes">-</div>
                 </div>
             </div>
         </div>

--- a/main/db_mavlink_msgs.c
+++ b/main/db_mavlink_msgs.c
@@ -18,6 +18,7 @@
  */
 #include <string.h>
 #include <esp_log.h>
+#include <esp_timer.h>
 
 #include "db_mavlink_msgs.h"
 #include "db_parameters.h"

--- a/main/db_mavlink_msgs.c
+++ b/main/db_mavlink_msgs.c
@@ -36,6 +36,22 @@
 #define FASTMAVLINK_ROUTER_COMPONENTS_MAX  5
 
 #define TAG "DB_MAV_MSGS"
+uint8_t DB_MAV_SYS_ID = 1;
+uint32_t last_fc_heartbeat_ms = 0;
+
+/**
+ * Returns true if we recently saw a heartbeat from a flight controller on the serial link
+ */
+bool fc_connected() {
+    return (esp_timer_get_time() / 1000 - last_fc_heartbeat_ms) < 2500;
+}
+
+/**
+ * Returns the current flight controller system ID (last seen)
+ */
+uint8_t db_get_fc_sys_id() {
+    return DB_MAV_SYS_ID;
+}
 
 /**
  * Based on the system architecture and configured wifi mode the ESP32 may have a different role and system id.
@@ -334,6 +350,7 @@ void handle_mavlink_message(fmav_message_t *new_msg, int *tcp_clients, udp_conn_
                     // This means we are connected to the FC since we only parse mavlink on UART and thus only see the
                     // device we are connected to via UART
                     DB_MAV_SYS_ID = new_msg->sysid;
+                    last_fc_heartbeat_ms = esp_timer_get_time() / 1000;
                     // Check if FC is armed and the Wi-Fi switch based on armed status is configured by the user
                     if (DB_PARAM_DIS_RADIO_ON_ARM &&
                     (payload.base_mode & MAV_MODE_FLAG_SAFETY_ARMED ||

--- a/main/db_mavlink_msgs.h
+++ b/main/db_mavlink_msgs.h
@@ -29,6 +29,8 @@
 
 uint8_t db_get_mav_comp_id();
 uint8_t db_get_mav_sys_id();
+bool fc_connected();
+uint8_t db_get_fc_sys_id();
 int8_t db_format_rssi(int8_t signal_strength, int8_t noise_floor);
 uint16_t db_mav_create_heartbeat(uint8_t *buff, fmav_status_t *fmav_status);
 uint16_t db_get_mavmsg_param_value(uint8_t *buff, fmav_status_t *fmav_status, uint16_t param_index, float_int_union *value, uint8_t type, char *param_id);

--- a/main/db_serial.c
+++ b/main/db_serial.c
@@ -46,7 +46,6 @@
 
 #define TAG "DB_SERIAL"
 
-uint8_t DB_MAV_SYS_ID = 1;
 uint32_t serial_total_byte_count = 0;
 uint32_t serial_total_decoded_mav_msgs = 0;
 uint16_t DB_SERIAL_READ_TIMEOUT_MS = DB_SERIAL_READ_TIMEOUT_MS_DEFAULT;

--- a/main/http_server.c
+++ b/main/http_server.c
@@ -32,6 +32,7 @@
 #include "globals.h"
 #include "main.h"
 #include "db_serial.h"
+#include "db_mavlink_msgs.h"
 
 #define TAG "DB_HTTP_REST"
 #define REST_CHECK(a, str, goto_tag, ...)                                              \
@@ -332,6 +333,8 @@ static esp_err_t system_stats_get_handler(httpd_req_t *req) {
     cJSON_AddNumberToObject(root, "serial_dec_mav_msgs", serial_total_decoded_mav_msgs);
     cJSON_AddNumberToObject(root, "tcp_connected", num_connected_tcp_clients);
     cJSON_AddNumberToObject(root, "udp_connected", udp_conn_list->size);
+    cJSON_AddBoolToObject(root, "fc_connected", fc_connected());
+    cJSON_AddNumberToObject(root, "fc_sys_id", db_get_fc_sys_id());
     // add IP:PORT info on connected UDP clients
     cJSON *udp_clients = cJSON_CreateArray();
     for (int i = 0; i < udp_conn_list->size; i++) {


### PR DESCRIPTION
Summary

Displays the connected flight controller's MAVLink System ID in the status section of the web interface. If no flight controller is connected, a "No Flight Controller connected." message is shown instead.

Changes

Backend:
- Moved DB_MAV_SYS_ID and FC connection tracking from db_serial.c to db_mavlink_msgs.c where it logically belongs
- Added fc_connected() — returns true if a FC heartbeat was seen on serial within the last 2.5 seconds
- Added db_get_fc_sys_id() — returns the last seen FC system ID
- Extended the /system_stats REST endpoint with fc_connected (bool) and fc_sys_id (uint8)

Frontend:
- Added a status line below the client IP showing either "MAVLink System ID: X" or "No Flight Controller connected", updated on every stats poll