### PR TITLE
Auto-remove unreachable UDP clients on repeated send failures

### DIFF
--- a/main/db_esp32_control.c
+++ b/main/db_esp32_control.c
@@ -176,7 +176,20 @@ void db_send_to_all_udp_clients(const uint8_t *data, uint data_length) {
         if (sent != data_length) {
             int err = errno;
             char *client_ip = inet_ntoa(((struct sockaddr_in *)&udp_conn_list->db_udp_clients[i].udp_client)->sin_addr);
-            ESP_LOGE(TAG, "UDP - Error sending (%i/%i) to %s because of %s", sent, data_length, client_ip, strerror(err));
+            udp_conn_list->db_udp_clients[i].send_fail_count++;
+            if (udp_conn_list->db_udp_clients[i].send_fail_count >= 5) {
+                ESP_LOGW(TAG, "UDP - Removing unreachable client %s after repeated send failures (last errno: %d)",
+                         client_ip, err);
+                for (int j = i; j < udp_conn_list->size - 1; j++) {
+                    udp_conn_list->db_udp_clients[j] = udp_conn_list->db_udp_clients[j + 1];
+                }
+                udp_conn_list->size--;
+                i--;
+            } else {
+                ESP_LOGE(TAG, "UDP - Error sending (%i/%i) to %s because of %s", sent, data_length, client_ip, strerror(err));
+            }
+        } else {
+            udp_conn_list->db_udp_clients[i].send_fail_count = 0;
         }
     }
 }

--- a/main/db_esp32_control.h
+++ b/main/db_esp32_control.h
@@ -33,6 +33,7 @@
 struct db_udp_client_t {
     uint8_t mac[6];     // MAC address of connected client
     struct sockaddr_in udp_client;    // socket address (IP & PORT) of connected client
+    uint8_t send_fail_count; // consecutive send failures; client removed when exceeds threshold
 };
 
 typedef struct udp_conn_list_s {


### PR DESCRIPTION
Problem

When a UDP client (e.g. a GCS laptop) disconnects from the Wi-Fi network without sending any further packets, the ESP32 has no way to detect the disconnect via the connectionless UDP protocol. Subsequent sendto() calls to the stale client return ENOMEM (errno 12), causing a flood of error log messages until the device is rebooted or the client reconnects.

Fix

Added a send_fail_count field to db_udp_client_t. Each consecutive send failure to a client increments the counter; a successful send resets it to zero. After 5 consecutive failures the client is removed from the UDP distribution list with a warning log, silencing the error spam and freeing the slot for new clients.